### PR TITLE
Add option to set the base API url

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,16 +5,22 @@ import {
   register,
   State,
 } from './state';
-import { initSend, send } from './send';
+import { initSend, setBaseUrl, send } from './send';
 
 export type { State } from './state';
 export { register } from './state';
 export { mute, unmute } from './send';
 
 const rand16 = () => Math.random().toString(36).slice(2, 10);
-
-export function init(token: string) {
+/**
+ * If you need a different base URL rather than https://api.mixpanel.com, pass it as the second argument to `init`.
+ * (e.g. when using a proxy to track events)
+ */
+export function init(token: string, baseUrl?: string) {
   initState(token);
+  if (baseUrl) {
+    setBaseUrl(baseUrl);
+  }
   return initSend();
 }
 

--- a/src/send.ts
+++ b/src/send.ts
@@ -6,9 +6,15 @@ import {
   State,
 } from './state';
 
-const TRACKING_URL = 'https://api.mixpanel.com/track';
-const ENGAGE_URL = 'https://api.mixpanel.com/engage';
 const ATTEMPTS = 3;
+
+let trackingUrl = 'https://api.mixpanel.com/track';
+let engageUrl = 'https://api.mixpanel.com/engage';
+
+export function setBaseUrl(url: string) {
+  trackingUrl = url + '/track';
+  engageUrl = url + '/engage';
+}
 
 function base64(input: string): string {
   return btoa(unescape(encodeURIComponent(input)));
@@ -71,7 +77,7 @@ export const _assemblePayload = (data: Payload): Payload => {
 };
 
 export async function _flushPayload(data: Payload) {
-  const baseUrl = '$set' in data ? ENGAGE_URL : TRACKING_URL;
+  const baseUrl = '$set' in data ? engageUrl : trackingUrl;
   const payload: Payload = _assemblePayload(data);
   const serialized = base64(JSON.stringify(payload, replacer));
   const timestamp = Date.now();


### PR DESCRIPTION
Adds an option to the `init` function to pass in a base URL. This helps with use cases like passing requests through a proxy that then sends those to mixpanel.

![CleanShot 2024-02-12 at 13 29 18](https://github.com/0no-co/mixpanel-micro/assets/11748696/6ad71866-b1a7-41e3-822c-12b62f6ede3d)
